### PR TITLE
feat: parameterize preprocessing batch size

### DIFF
--- a/modules/export_covid19_dataset.py
+++ b/modules/export_covid19_dataset.py
@@ -116,13 +116,13 @@ def main(arguments):
         batch_size=batch_size,
     )
     train_dataset = (train_features, train_labels)
-    export_dataset(train_dataset, os.path.join(path, "train.pt"))
+    export_dataset(train_dataset, os.path.join(path, f"train_{arguments.size}.pt"))
     test_features, test_labels = unpack_examples(test_loader)
     test_features, test_labels = vectorize_examples(
         test_features, test_labels, dataset_size=len(test_data), batch_size=batch_size
     )
     test_dataset = (test_features, test_labels)
-    export_dataset(test_dataset, os.path.join(path, "test.pt"))
+    export_dataset(test_dataset, os.path.join(path, f"test_{arguments.size}.pt"))
 
 
 if __name__ == "__main__":

--- a/modules/export_covid19_dataset.py
+++ b/modules/export_covid19_dataset.py
@@ -29,12 +29,8 @@ from pt_datasets import load_dataset, create_dataloader
 __author__ = "Abien Fred Agarap"
 
 
-BINARY_COVID19_PATH = os.path.join(
-    str(Path.home()), "torch_datasets/BinaryCOVID19Dataset"
-)
-MULTI_COVID19_PATH = os.path.join(
-    str(Path.home()), "torch_datasets/MultiCOVID19Dataset"
-)
+BINARY_COVID19_PATH = os.path.join(str(Path.home()), "datasets/BinaryCOVID19Dataset")
+MULTI_COVID19_PATH = os.path.join(str(Path.home()), "datasets/MultiCOVID19Dataset")
 
 
 def parse_args():

--- a/modules/export_covid19_dataset.py
+++ b/modules/export_covid19_dataset.py
@@ -106,8 +106,8 @@ def main(arguments):
     )
     assert arguments.dataset in ["binary_covid", "multi_covid"]
     train_data, test_data = load_dataset(arguments.dataset, image_size=arguments.size)
-    train_loader = create_dataloader(train_data, batch_size=batch_size)
-    test_loader = create_dataloader(test_data, batch_size=len(test_data))
+    train_loader = create_dataloader(train_data, batch_size=batch_size, num_workers=4)
+    test_loader = create_dataloader(test_data, batch_size=len(test_data), num_workers=4)
     train_features, train_labels = unpack_examples(train_loader)
     train_features, train_labels = vectorize_examples(
         train_features,

--- a/pt_datasets/COVID19Dataset.py
+++ b/pt_datasets/COVID19Dataset.py
@@ -341,7 +341,9 @@ def preprocess_dataset(
         elif "MultiCOVID19Dataset" in export_dir:
             train_data = MultiCOVID19Dataset(train=True, size=size, transform=transform)
         print("[INFO] Creating data loader...")
-        train_loader = create_dataloader(train_data, batch_size=batch_size)
+        train_loader = create_dataloader(
+            train_data, batch_size=batch_size, num_workers=4
+        )
         print("[INFO] Unpacking examples...")
         train_features, train_labels = unpack_examples(train_loader)
         print("[INFO] Vectorizing examples...")
@@ -368,7 +370,7 @@ def preprocess_dataset(
         elif "MultiCOVID19Dataset" in export_dir:
             test_data = MultiCOVID19Dataset(train=False, size=size, transform=transform)
         print("[INFO] Creating data loader...")
-        test_loader = create_dataloader(test_data, batch_size=batch_size)
+        test_loader = create_dataloader(test_data, batch_size=batch_size, num_workers=4)
         print("[INFO] Unpacking examples...")
         test_features, test_labels = unpack_examples(test_loader)
         print("[INFO] Vectorizing examples...")

--- a/pt_datasets/COVID19Dataset.py
+++ b/pt_datasets/COVID19Dataset.py
@@ -86,13 +86,23 @@ class BinaryCOVID19Dataset(torch.utils.data.Dataset):
                     batch_size=preprocessing_bsize,
                 )
             if train:
-                dataset = torch.load(
-                    os.path.join(BINARY_COVID19_DIR, f"train_{size}.pt")
-                )
+                if size > 64:
+                    dataset = load_pickle(
+                        os.path.join(BINARY_COVID19_DIR, f"train_{size}.pt")
+                    )
+                else:
+                    dataset = torch.load(
+                        os.path.join(BINARY_COVID19_DIR, f"train_{size}.pt")
+                    )
             else:
-                dataset = torch.load(
-                    os.path.join(BINARY_COVID19_DIR, f"test_{size}.pt")
-                )
+                if size > 64:
+                    dataset = load_pickle(
+                        os.path.join(BINARY_COVID19_DIR, f"test_{size}.pt")
+                    )
+                else:
+                    dataset = torch.load(
+                        os.path.join(BINARY_COVID19_DIR, f"test_{size}.pt")
+                    )
             self.data = dataset[0]
             self.labels = dataset[1]
         else:
@@ -185,11 +195,23 @@ class MultiCOVID19Dataset(torch.utils.data.Dataset):
                     batch_size=preprocessing_bsize,
                 )
             if train:
-                dataset = torch.load(
-                    os.path.join(MULTI_COVID19_DIR, f"train_{size}.pt")
-                )
+                if size > 64:
+                    dataset = load_pickle(
+                        os.path.join(MULTI_COVID19_DIR, f"train_{size}.pt")
+                    )
+                else:
+                    dataset = torch.load(
+                        os.path.join(MULTI_COVID19_DIR, f"train_{size}.pt")
+                    )
             else:
-                dataset = torch.load(os.path.join(MULTI_COVID19_DIR, f"test_{size}.pt"))
+                if size > 64:
+                    dataset = load_pickle(
+                        os.path.join(MULTI_COVID19_DIR, f"test_{size}.pt")
+                    )
+                else:
+                    dataset = torch.load(
+                        os.path.join(MULTI_COVID19_DIR, f"test_{size}.pt")
+                    )
             self.data = dataset[0]
             self.labels = dataset[1]
         if train:
@@ -388,3 +410,11 @@ def preprocess_dataset(
             )
         )
         export_dataset(test_dataset, os.path.join(export_dir, f"test_{size}.pt"))
+
+
+def load_pickle(
+    filename: str
+) -> Tuple[np.ndarray or torch.Tensor, np.ndarray or torch.Tensor]:
+    with open(filename, "rb") as tensor_file:
+        dataset = pickle.load(tensor_file)
+    return dataset

--- a/pt_datasets/COVID19Dataset.py
+++ b/pt_datasets/COVID19Dataset.py
@@ -70,11 +70,19 @@ class BinaryCOVID19Dataset(torch.utils.data.Dataset):
                 print(
                     "[INFO] No preprocessed training dataset found. Preprocessing now..."
                 )
-                preprocess_dataset(train=True, size=size, export_dir=BINARY_COVID19_DIR)
+                preprocess_dataset(
+                    train=True,
+                    size=size,
+                    export_dir=BINARY_COVID19_DIR,
+                    batch_size=preprocessing_bsize,
+                )
             if not os.path.isfile(os.path.join(BINARY_COVID19_DIR, f"test_{size}.pt")):
                 print("[INFO] No preprocessed test dataset found. Preprocessing now...")
                 preprocess_dataset(
-                    train=False, size=size, export_dir=BINARY_COVID19_DIR
+                    train=False,
+                    size=size,
+                    export_dir=BINARY_COVID19_DIR,
+                    batch_size=preprocessing_bsize,
                 )
             if train:
                 dataset = torch.load(
@@ -161,10 +169,20 @@ class MultiCOVID19Dataset(torch.utils.data.Dataset):
                 print(
                     "[INFO] No preprocessed training dataset found. Preprocessing now..."
                 )
-                preprocess_dataset(train=True, size=size, export_dir=MULTI_COVID19_DIR)
+                preprocess_dataset(
+                    train=True,
+                    size=size,
+                    export_dir=MULTI_COVID19_DIR,
+                    batch_size=preprocessing_bsize,
+                )
             if not os.path.isfile(os.path.join(MULTI_COVID19_DIR, f"test_{size}.pt")):
                 print("[INFO] No preprocessed test dataset found. Preprocessing now...")
-                preprocess_dataset(train=False, size=size, export_dir=MULTI_COVID19_DIR)
+                preprocess_dataset(
+                    train=False,
+                    size=size,
+                    export_dir=MULTI_COVID19_DIR,
+                    batch_size=preprocessing_bsize,
+                )
             if train:
                 dataset = torch.load(
                     os.path.join(MULTI_COVID19_DIR, f"train_{size}.pt")

--- a/pt_datasets/COVID19Dataset.py
+++ b/pt_datasets/COVID19Dataset.py
@@ -415,6 +415,20 @@ def preprocess_dataset(
 def load_pickle(
     filename: str
 ) -> Tuple[np.ndarray or torch.Tensor, np.ndarray or torch.Tensor]:
+    """
+    Loads the pickled dataset.
+
+    Parameter
+    ---------
+    filename: str
+        The path to the pickled dataset.
+
+    Returns
+    -------
+    Tuple[np.ndarray or torch.Tensor, np.ndarray or torch.Tensor]
+        The first element is the features tensor.
+        The second element is the labels tensor.
+    """
     with open(filename, "rb") as tensor_file:
         dataset = pickle.load(tensor_file)
     return dataset

--- a/pt_datasets/COVID19Dataset.py
+++ b/pt_datasets/COVID19Dataset.py
@@ -16,6 +16,7 @@
 """COVID19 dataset classes"""
 import os
 from pathlib import Path
+import pickle
 import time
 from typing import Dict, List, Tuple
 
@@ -320,7 +321,11 @@ def export_dataset(dataset: Tuple[np.ndarray, np.ndarray], filename: str) -> Non
     """
     if not filename.endswith(".pt"):
         filename = f"{filename}.pt"
-    torch.save(dataset, filename)
+    if dataset[0].shape[2] > 64:
+        with open(filename, "wb") as tensor_file:
+            pickle.dump(dataset, tensor_file)
+    else:
+        torch.save(dataset, filename)
 
 
 def preprocess_dataset(

--- a/pt_datasets/COVID19Dataset.py
+++ b/pt_datasets/COVID19Dataset.py
@@ -47,6 +47,7 @@ class BinaryCOVID19Dataset(torch.utils.data.Dataset):
         transform: torchvision.transforms = None,
         size: int = 64,
         preprocessed: bool = False,
+        preprocessing_bsize: int = 2048,
     ):
         """
         Builds the COVID19 binary classification dataset.
@@ -59,8 +60,10 @@ class BinaryCOVID19Dataset(torch.utils.data.Dataset):
             The transformation pipeline to use for image preprocessing.
         size: int
             The size to use for resizing images.
-        preproceseed: bool
+        preprocessed: bool
             Whether to load preprocessed dataset or not.
+        preprocessing_bsize: int
+            The mini-batch size to use preprocessing the dataset.
         """
         if preprocessed:
             if not os.path.isfile(os.path.join(BINARY_COVID19_DIR, f"train_{size}.pt")):
@@ -135,6 +138,7 @@ class MultiCOVID19Dataset(torch.utils.data.Dataset):
         transform: torchvision.transforms = None,
         size: int = 64,
         preprocessed: bool = False,
+        preprocessing_bsize: int = 2048,
     ):
         """
         Builds the COVID19 multi-classification dataset.
@@ -149,6 +153,8 @@ class MultiCOVID19Dataset(torch.utils.data.Dataset):
             The size to use for resizing images.
         preprocessed: bool
             Whether to load preprocessed dataset or not.
+        preprocessing_bsize: int
+            The mini-batch size to use preprocessing the dataset.
         """
         if preprocessed:
             if not os.path.isfile(os.path.join(MULTI_COVID19_DIR, f"train_{size}.pt")):


### PR DESCRIPTION
Instead of a fixed preprocessing batch size, use a variable one to control the memory used during preprocessing.
At `preprocessing_bsize=256`, we can successfully pickle a 128x128 COVID19 dataset.